### PR TITLE
Add 'browser' property for lean browser builds

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,1 @@
+module.exports = XMLHttpRequest;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sinon-chai": ">= 2.5.0"
   },
   "main": "lib/xhr2.js",
+  "browser": "lib/browser.js",
   "directories": {
     "doc": "doc",
     "lib": "lib",


### PR DESCRIPTION
This change adds the ['browser' property](https://github.com/substack/node-browserify#browser-field) to `package.json` and a simple browser fallback which allows this library to be used for isomorphic projects while keeping the compiled browser output extremely lean.

When compiling code for the browser, Browserify will use `browser.js` instead of `xhr2.js`, so this whole library becomes a single line: `module.exports = XMLHttpRequest`.

I've tried this in a project I'm currently working on and it works great. Do you have any concerns with this?