### PR TITLE
Fix removeEventListener

### DIFF
--- a/src/000-xml_http_request_event_target.coffee
+++ b/src/000-xml_http_request_event_target.coffee
@@ -71,7 +71,7 @@ class XMLHttpRequestEventTarget
     eventType = eventType.toLowerCase()
     if @_listeners[eventType]
       index = @_listeners[eventType].indexOf listener
-      @_listeners.splice index, 1 if index isnt -1
+      @_listeners[eventType].splice index, 1 if index isnt -1
     undefined
 
   # Calls all the listeners for an event.


### PR DESCRIPTION
Fix for removeEventListener - splice should be applied on the array of an eventType