### PR TITLE
Added FormData support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "xhr2",
   "version": "0.1.4",
   "description": "XMLHttpRequest emulation for node.js",
-  "keywords": ["xhr", "xmlhttprequest", "ajax", "browser"],
+  "keywords": [
+    "xhr",
+    "xmlhttprequest",
+    "ajax",
+    "browser"
+  ],
   "homepage": "https://github.com/pwnall/node-xhr2",
   "author": "Victor Costan <victor@costan.us> (http://www.costan.us)",
   "contributors": [
@@ -21,6 +26,7 @@
     "node": ">= 0.6"
   },
   "dependencies": {
+    "form-data": "^2.1.4"
   },
   "devDependencies": {
     "async": ">= 1.4.2",

--- a/src/001-xml_http_request.coffee
+++ b/src/001-xml_http_request.coffee
@@ -780,3 +780,6 @@ module.exports = XMLHttpRequest
 # following usage pattern:
 #     var XMLHttpRequest = require('xhr-library-name').XMLHttpRequest
 XMLHttpRequest.XMLHttpRequest = XMLHttpRequest
+
+
+XMLHttpRequest.FormData = require('form-data')

--- a/src/xml_http_request_upload.coffee
+++ b/src/xml_http_request_upload.coffee
@@ -1,3 +1,5 @@
+FormData = require('form-data')
+
 # @see http://xhr.spec.whatwg.org/#interface-xmlhttprequest
 class XMLHttpRequestUpload extends XMLHttpRequestEventTarget
   # @private
@@ -48,6 +50,13 @@ class XMLHttpRequestUpload extends XMLHttpRequestEventTarget
       offset = data.byteOffset
       view = new Uint8Array data.buffer
       body[i] = view[i + offset] for i in [0...data.byteLength]
+      @_body = body
+    else if data instanceof FormData
+      body = ''
+      data.on('data', (data) -> body += data.toString())
+      data.resume()
+      while !data.pauseStreams then
+      @_contentType = data.getHeaders()['content-type']
       @_body = body
     else
       # NOTE: diverging from the XHR specification of coercing everything else


### PR DESCRIPTION
This PR adds basic `FormData` support using the [`form-data`](https://github.com/form-data/form-data) module (same module that `request` uses). This may not cover all cases, but it's working in my project so I thought I'd share.

Here's an example of how you'd use this to polyfill `FormData` in Node:

```js
import XMLHttpRequest from 'xhr2';
global.XMLHttpRequest = XMLHttpRequest;
global.FormData = XMLHttpRequest.FormData;
```
