### PR TITLE
support for coffeescript 2.0

### DIFF
--- a/src/errors.coffee
+++ b/src/errors.coffee
@@ -3,7 +3,7 @@
 # Thrown if the XHR security policy is violated.
 class SecurityError extends Error
   # @private
-  constructor: -> super
+  constructor: -> super()
 
 # Thrown if the XHR security policy is violated.
 XMLHttpRequest.SecurityError = SecurityError
@@ -12,7 +12,7 @@ XMLHttpRequest.SecurityError = SecurityError
 # Usually thrown if the XHR is in the wrong readyState for an operation.
 class InvalidStateError extends Error
   # @private
-  constructor: -> super
+  constructor: -> super()
 
 # Usually thrown if the XHR is in the wrong readyState for an operation.
 class InvalidStateError extends Error
@@ -21,11 +21,11 @@ XMLHttpRequest.InvalidStateError = InvalidStateError
 # Thrown if there is a problem with the URL passed to the XHR.
 class NetworkError extends Error
   # @private
-  constructor: -> super
+  constructor: -> super()
 
 # Thrown if parsing URLs errors out.
 XMLHttpRequest.SyntaxError = SyntaxError
 
 class SyntaxError extends Error
   # @private:
-  constructor: -> super
+  constructor: -> super()


### PR DESCRIPTION
In CoffeeScript 2, “bare” super (calling super without arguments) is now no longer allowed, and one must use super() or super arguments... instead.

see https://coffeescript.org/announcing-coffeescript-2/