### PR TITLE
Fix for [DEP0005] Buffer() is deprecated

### DIFF
--- a/src/001-xml_http_request.coffee
+++ b/src/001-xml_http_request.coffee
@@ -8,6 +8,12 @@ https = require 'https'
 os = require 'os'
 url = require 'url'
 
+bufferAlloc = (size) -> 
+  if Buffer.alloc then Buffer.alloc(size) else new Buffer(size)
+
+bufferFrom = (string, encoding) -> 
+  if Buffer.from then Buffer.from(string, encoding) else new Buffer(string, encoding)
+
 # The ECMAScript HTTP API.
 #
 # @see http://www.w3.org/TR/XMLHttpRequest/#introduction
@@ -760,13 +766,13 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget
   # @return {Buffer} same as Buffer.concat(buffers) in node 0.8 and above
   _concatBuffers: (buffers) ->
     if buffers.length is 0
-      return new Buffer 0
+      return bufferAlloc 0
     if buffers.length is 1
       return buffers[0]
 
     length = 0
     length += buffer.length for buffer in buffers
-    target = new Buffer length
+    target = bufferAlloc length
     length = 0
     for buffer in buffers
       buffer.copy target, length

--- a/src/xml_http_request_upload.coffee
+++ b/src/xml_http_request_upload.coffee
@@ -32,19 +32,19 @@ class XMLHttpRequestUpload extends XMLHttpRequestEventTarget
       # DOMString
       if data.length isnt 0
         @_contentType = 'text/plain;charset=UTF-8'
-      @_body = new Buffer data, 'utf8'
+      @_body = bufferFrom data, 'utf8'
     else if Buffer.isBuffer data
       # node.js Buffer
       @_body = data
     else if data instanceof ArrayBuffer
       # ArrayBuffer arguments were supported in an old revision of the spec.
-      body = new Buffer data.byteLength
+      body = bufferAlloc data.byteLength
       view = new Uint8Array data
       body[i] = view[i] for i in [0...data.byteLength]
       @_body = body
     else if data.buffer and data.buffer instanceof ArrayBuffer
       # ArrayBufferView
-      body = new Buffer data.byteLength
+      body = bufferAlloc data.byteLength
       offset = data.byteOffset
       view = new Uint8Array data.buffer
       body[i] = view[i + offset] for i in [0...data.byteLength]

--- a/test/src/send_test.coffee
+++ b/test/src/send_test.coffee
@@ -9,7 +9,7 @@ describe 'XMLHttpRequest', ->
       if typeof Buffer is 'undefined'
         @buffer = null
       else
-        @buffer = new Buffer xhr2PngBytes.length
+        @buffer = if Buffer.alloc then Buffer.alloc xhr2PngBytes.length else new Buffer xhr2PngBytes.length 
 
       for i in [0...xhr2PngBytes.length]
         @arrayBufferView[i] = xhr2PngBytes[i]


### PR DESCRIPTION
This PR fix #33 