### PR TITLE
Throw on attempting a Synchronous open.

### DIFF
--- a/src/001-xml_http_request.coffee
+++ b/src/001-xml_http_request.coffee
@@ -106,6 +106,8 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget
 
     xhrUrl = @_parseUrl url
     async = true if async is undefined
+    if async == false
+      throw new Error "Synchronous (async=false) XMLHttpRequests are unsupported"
 
     switch @readyState
       when XMLHttpRequest.UNSENT, XMLHttpRequest.OPENED, XMLHttpRequest.DONE


### PR DESCRIPTION
Relates to #19.
Currently attempting to use a Synchronous `XMLHttpRequest.open()` will fail in weird ways. This makes the failure explicit.