### PR TITLE
Fix 'TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters'

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "engines": {
     "node": ">= 6"
   },
-  "dependencies": {},
+  "dependencies": {
+    "native-url": "^0.3.4"
+  },
   "devDependencies": {
     "async": ">=3.0.1",
     "chai": ">=4.2.0",

--- a/src/001-xml_http_request.coffee
+++ b/src/001-xml_http_request.coffee
@@ -6,7 +6,7 @@
 http = require 'http'
 https = require 'https'
 os = require 'os'
-url = require 'url'
+url = require 'native-url'
 
 # The ECMAScript HTTP API.
 #
@@ -105,6 +105,8 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget
       throw new SecurityError "HTTP method #{method} is not allowed in XHR"
 
     xhrUrl = @_parseUrl url
+    xhrUrl.path = encodeURI xhrUrl.path
+
     async = true if async is undefined
 
     switch @readyState

--- a/test/src/helpers/xhr_server.coffee
+++ b/test/src/helpers/xhr_server.coffee
@@ -95,6 +95,10 @@ class XhrServer
         response.write json.body if json.body
         response.end()
 
+    # Returns a given URL parameter. Used for URL encoding testing.
+    @app.all '/_/url/:arg', (request, response) =>
+      response.json request.params.arg
+
     # Sends data in small chunks. Used for event testing.
     @app.post '/_/drip', (request, response) ->
       request.connection.setNoDelay()

--- a/test/src/xhr_test.coffee
+++ b/test/src/xhr_test.coffee
@@ -70,6 +70,28 @@ describe 'XMLHttpRequest', ->
           done()
         @xhr.send()
 
+    describe 'on an unencoded URL', ->
+      beforeEach ->
+        @xhr.open 'GET', 'http://localhost:8912/_/url/💻'
+
+      it 'encodes correctly', (done) ->
+        @xhr.onload = (event) =>
+          expect(@xhr.status).to.equal 200
+          expect(@xhr.responseText).to.equal '"💻"'
+          done()
+        @xhr.send()
+
+    describe 'on an encoded URL', ->
+      beforeEach ->
+        @xhr.open 'GET', 'http://localhost:8912/_/url/%F0%9F%92%BB'
+
+      it 'does not double-encode', (done) ->
+        @xhr.onload = (event) =>
+          expect(@xhr.status).to.equal 200
+          expect(@xhr.responseText).to.equal '"💻"'
+          done()
+        @xhr.send()
+
   describe 'on a local gopher GET', ->
     describe '#open + #send', ->
       it 'throw a NetworkError', ->


### PR DESCRIPTION
It appears most browsers (tested in Firefox, Safari and Chromium[Chrome/Brave]) will url-encode paths automatically if they are not already encoded.

`xhr2` doesn't match that behaviour when run in node: using an unencoded URL will result in `TypeError [ERR_UNESCAPED_CHARACTERS]`.

Just adding the encoding line however causes a new issue; already encoded URLs end up being double-encoded, changing the URL incorrectly.

Using [`native-url`](https://github.com/GoogleChromeLabs/native-url instead of `url` fixes this, as well as removing the dependency on the deprecated [Legacy URL API](https://nodejs.org/api/url.html#url_legacy_url_api).

It would have of course been better to refactor `xhr2` to not use the deprecated API, however this does not appear to be trivial looking at the [`native-url` code](https://github.com/GoogleChromeLabs/native-url/tree/master/src) – at least, I am not able to do that work presently.

I'm not necessarily expecting this to get merged (I think the fact that `xhr2` has no dependencies is pretty nice!), but I figured it might be useful for anyone else that runs into the `ERR_UNESCAPED_CHARACTERS` issue, or for the project maintainers as they're considering how to deal with the API deprecation.